### PR TITLE
Add a basic CI runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: Nix Build & Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout flake
+        uses: actions/checkout@v4
+
+      - name: Install nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Setup magic-nix-cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: nix build
+        run: nix build '.?submodules=1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,5 +19,6 @@ jobs:
       - name: Setup magic-nix-cache
         uses: DeterminateSystems/magic-nix-cache-action@main
 
+      # Nix versions >2.18 seem to be broken with submodules
       - name: nix build
-        run: nix build --debug '.?submodules=1'
+        run: nix run nixpkgs\#nixVersions.nix_2_18 -- build '.?submodules=1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout flake
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Install nix
         uses: DeterminateSystems/nix-installer-action@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,4 +20,4 @@ jobs:
         uses: DeterminateSystems/magic-nix-cache-action@main
 
       - name: nix build
-        run: nix build '.?submodules=1'
+        run: nix build --debug '.?submodules=1'


### PR DESCRIPTION
CI that just builds the program. We can't run tests because GitHub doesn't offer CUDA capable runners.